### PR TITLE
Feature/snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ in the dedent area).
 Using the `snippet` attribute, one may use ``pandoc-include-code`` style 
 snippets, for instance
 
-    ```{.python include="script.py" snippet="main"
+    ```{.python include="script.py" snippet="main"}
     ```
 
 will include the snippet 'main' which is enclosed between ``# start snippet main``

--- a/README.md
+++ b/README.md
@@ -56,3 +56,28 @@ in the dedent area).
     ```{.python include="script.py" dedent=4}
     ```
 
+### Snippets
+
+Using the `snippet` attribute, one may use ``pandoc-include-code`` style 
+snippets, for instance
+
+    ```{.python include="script.py" snippet="main"
+    ```
+
+will include the snippet 'main' which is enclosed between ``# start snippet main``
+and ``# end snippet main`` in the following 
+
+```python
+# script.py
+
+# start snippet main
+def main():
+    print("It works!")
+
+# end snippet main
+```
+
+
+For now this should support include for ``python``, ``r``, ``julia``, ``html``,
+``js``, ``ojs``, and ``css``. It might work on other documents too, but will 
+have to guess.

--- a/_extensions/include-code-files/include-code-files.lua
+++ b/_extensions/include-code-files/include-code-files.lua
@@ -4,12 +4,64 @@
 --- License:   MIT – see LICENSE file for details
 
 --- Dedent a line
-local function dedent (line, n)
-  return line:sub(1,n):gsub(" ","") .. line:sub(n+1)
+local function dedent(line, n)
+  return line:sub(1, n):gsub(" ", "") .. line:sub(n + 1)
+end
+
+--- Find snippet start and end.
+--
+--  Use this to populate startline and endline.
+--  This should work like pandocs snippet functionality: https://github.com/owickstrom/pandoc-include-code/tree/master
+local function snippet(cb, fh)
+  if not cb.attributes.snippet then
+    return
+  end
+
+  -- http://lua-users.org/wiki/PatternsTutorial
+  local comment
+  if
+    string.match(cb.attributes.include, ".py$")
+    or string.match(cb.attributes.include, ".jl$")
+    or string.match(cb.attributes.include, ".r$")
+  then
+    comment = "#"
+  elseif string.match(cb.attributes.include, ".ojs$") then
+    comment = "//"
+  end
+
+  local p_start = string.format("^ *%s start snippet %s", comment, cb.attributes.snippet)
+  local p_stop = string.format("^ *%s end snippet %s", comment, cb.attributes.snippet)
+
+  local start, stop = nil, nil
+
+  -- Cannot use pairs.
+  local line_no = 1
+  for line in fh:lines() do
+    if start == nil then
+      if string.match(line, p_start) then
+        start = line_no
+      end
+    elseif stop == nil then
+      if string.match(line, p_stop) then
+        stop = line_no
+      end
+    else
+      break
+    end
+    line_no = line_no + 1
+  end
+
+  -- If start and stop not found, just continue
+  if start == nil or stop == nil then
+    return nil
+  end
+
+  cb.attributes.startLine = start
+  cb.attributes.stopLine = stop
 end
 
 --- Filter function for code blocks
-local function transclude (cb)
+local function transclude(cb)
   if cb.attributes.include then
     local content = ""
     local fh = io.open(cb.attributes.include)
@@ -20,21 +72,23 @@ local function transclude (cb)
       local start = 1
 
       -- change hyphenated attributes to PascalCase
-      for i,pascal in pairs({"startLine", "endLine"})
-      do
-         local hyphen = pascal:gsub("%u", "-%0"):lower()
-         if cb.attributes[hyphen] then
-            cb.attributes[pascal] = cb.attributes[hyphen]
-            cb.attributes[hyphen] = nil
-         end
+      for i, pascal in pairs({ "startLine", "endLine" }) do
+        local hyphen = pascal:gsub("%u", "-%0"):lower()
+        if cb.attributes[hyphen] then
+          cb.attributes[pascal] = cb.attributes[hyphen]
+          cb.attributes[hyphen] = nil
+        end
       end
+
+      -- Overwrite startLine and stopLine with the snippet if any.
+      snippet(cb, fh)
 
       if cb.attributes.startLine then
         cb.attributes.startFrom = cb.attributes.startLine
         start = tonumber(cb.attributes.startLine)
       end
-      for line in fh:lines ("L")
-      do
+
+      for line in fh:lines("L") do
         if cb.attributes.dedent then
           line = dedent(line, cb.attributes.dedent)
         end
@@ -44,20 +98,22 @@ local function transclude (cb)
           end
         end
         number = number + 1
-      end 
+      end
+
       fh:close()
-    end     
+    end
+
     -- remove key-value pair for used keys
     cb.attributes.include = nil
     cb.attributes.startLine = nil
     cb.attributes.endLine = nil
     cb.attributes.dedent = nil
+
     -- return final code block
     return pandoc.CodeBlock(content, cb.attr)
   end
 end
 
 return {
-  { CodeBlock = transclude }
+  { CodeBlock = transclude },
 }
-

--- a/_extensions/include-code-files/include-code-files.lua
+++ b/_extensions/include-code-files/include-code-files.lua
@@ -17,21 +17,29 @@ local function snippet(cb, fh)
     return
   end
 
-  -- http://lua-users.org/wiki/PatternsTutorial
+  -- Cannot capture enum: http://lua-users.org/wiki/PatternsTutorial
   local comment
+  local comment_stop = ""
   if
     string.match(cb.attributes.include, ".py$")
     or string.match(cb.attributes.include, ".jl$")
     or string.match(cb.attributes.include, ".r$")
   then
     comment = "#"
-  elseif string.match(cb.attributes.include, ".ojs$") then
+  elseif string.match(cb.attributes.include, ".o?js$") or string.match(cb.attributes.include, ".css$") then
     comment = "//"
+  elseif string.match(cb.attributes.include, ".lua$") then
+    comment = "--"
+  elseif string.match(cb.attributes.include, ".html$") then
+    comment = "<!%-%-"
+    comment_stop = " *%-%->"
+  else
+    -- If not known assume that it is something one or two long and not alphanumeric.
+    comment = "%W%W?"
   end
 
-  local p_start = string.format("^ *%s start snippet %s", comment, cb.attributes.snippet)
-  local p_stop = string.format("^ *%s end snippet %s", comment, cb.attributes.snippet)
-
+  local p_start = string.format("^ *%s start snippet %s%s", comment, cb.attributes.snippet, comment_stop)
+  local p_stop = string.format("^ *%s end snippet %s%s", comment, cb.attributes.snippet, comment_stop)
   local start, stop = nil, nil
 
   -- Cannot use pairs.

--- a/_extensions/include-code-files/include-code-files.lua
+++ b/_extensions/include-code-files/include-code-files.lua
@@ -39,11 +39,11 @@ local function snippet(cb, fh)
   for line in fh:lines() do
     if start == nil then
       if string.match(line, p_start) then
-        start = line_no
+        start = line_no + 1
       end
     elseif stop == nil then
       if string.match(line, p_stop) then
-        stop = line_no
+        stop = line_no - 1
       end
     else
       break
@@ -51,13 +51,16 @@ local function snippet(cb, fh)
     line_no = line_no + 1
   end
 
+  -- Reset so nothing is broken later on.
+  fh:seek("set")
+
   -- If start and stop not found, just continue
   if start == nil or stop == nil then
     return nil
   end
 
-  cb.attributes.startLine = start
-  cb.attributes.stopLine = stop
+  cb.attributes.startLine = tostring(start)
+  cb.attributes.endLine = tostring(stop)
 end
 
 --- Filter function for code blocks


### PR DESCRIPTION
Snippets functionality like [pandoc-include-code](https://github.com/owickstrom/pandoc-include-code).

For now this should support include for ``python``, ``r``, ``julia``, ``html``, ``js``, ``ojs``, and ``css``. It might work on other documents too, but will have to guess by searching for non-alphanumeric characters.
